### PR TITLE
Fixes from novatechweb/ansible-virtd-docker-mariadb-bacula-nginx

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 # defaults file for docker-networking
+
+docker_network_frontend: frontend

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,6 @@
 ---
-# handlers file for docker-networking
+
+- name: Restart NetworkManager
+  service:
+    name: NetworkManager
+    state: restarted

--- a/tasks/hosts.yml
+++ b/tasks/hosts.yml
@@ -1,0 +1,14 @@
+---
+# file: roles/docker-common/tasks/ip_addr.yaml
+# Add each service to the /etc/hosts file
+
+- name: "Build /etc/hosts file"
+  lineinfile:
+    path: /etc/hosts
+    regexp: '.*{{ hostname }}$'
+    line:  '{{ ip_addr }} {{ hostname }}'
+    state: present
+  vars:
+    ip_addr: '{{ lookup("vars", item + "_ip_addr") }}'
+    hostname: '{{ lookup("vars", item + "_hostname") }}'
+  loop: "{{ services }}"

--- a/tasks/ip_addr.yml
+++ b/tasks/ip_addr.yml
@@ -1,0 +1,45 @@
+---
+# file: roles/docker-common/tasks/ip_addr.yaml
+
+- name: install needed network manager libs
+  yum:
+    name: NetworkManager-glib
+    state: installed
+  notify: Restart NetworkManager
+
+# nmcli always returns 'changed', so we need
+# to manually detect changes to the interface file
+- name: Get interface checksum
+  command: nmcli connection show "{{ network_connection }}"
+  register: network_pre
+  changed_when: false
+
+- name: Add service IP addresses
+  command: >
+    nmcli connection
+    modify '{{ network_connection }}'
+    +ipv4.addresses '{{ ip_addr }}'
+  changed_when: true
+  vars:
+    ip_addr: '{{ lookup("vars", item + "_ip_addr") }}/{{ subnet | ipaddr("prefix") }}'
+  loop: "{{ services }}"
+
+
+- name: Enable ipv4 forwarding for Docker
+  sysctl:
+    name: net.ipv4.ip_forward
+    value: 1
+    sysctl_set: yes
+    state: present
+    reload: yes
+  when: ansible_os_family == "RedHat"
+
+- name: Get interface checksum
+  command: nmcli connection show "{{ network_connection }}"
+  register: network_post
+  changed_when: false
+
+- name: make IPs active if needed
+  command: nmcli connection up "{{ network_connection }}"
+  when:
+    - ( network_pre != network_post )

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,18 @@
 ---
 # tasks file for docker-networking
+
+- name: Check preconditions
+  assert:
+    that:
+    - network_connection is defined
+    - subnet is defined
+    - services is defined
+
+- import_tasks: ip_addr.yml
+
+- import_tasks: hosts.yml
+
+- name: Create frontend network for services
+  docker_network:
+    name: '{{ docker_network_frontend }}'
+    state: present


### PR DESCRIPTION
Clean up ip address assignment

Use system utilities (nmcli) to set IP addresses, and add checks to
cause as little disturbance as possible.

Hostnames for testdaedalus must match live daedalus in order for backup
restore functions to work properly.